### PR TITLE
Allow passing of args to fns

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,6 +3,8 @@
 # Release a new version of clj-headlights.
 #
 # Usage: ./scripts/release.sh X.Y.Z
+# Put this: {:auth {:repository-auth {#"clojars" {:username "logrhythm" :password "${clojars_password}"}}}} into ~/.lein/profiles.clj
+# It will authenticate you against clojars
 
 set -e
 

--- a/src/clj_headlights/clj_fn_call.clj
+++ b/src/clj_headlights/clj_fn_call.clj
@@ -15,12 +15,17 @@
       false)))
 
 (def CljCallArgument
+  "Args must be serializable"
   (s/constrained s/Any serializable?))
 
-(def CljCall (s/cond-pre Var [(s/one Var "processing-var") CljCallArgument]))
+(def CljCall
+  "A Clj Call is either a var or a vec of [Call Args]"
+  (s/cond-pre Var [(s/one Var "processing-var") CljCallArgument]))
 
 ; TODO: document me
-(defn to-serializable-clj-call [clj-call]
+(defn to-serializable-clj-call
+  "Turns a clojure fn call into a map of the call and parameters"
+  [clj-call]
   (if (var? clj-call)
     (to-serializable-clj-call [clj-call])
     (let [[var & params] clj-call
@@ -35,6 +40,7 @@
        :params (vec params)})))
 
 (defn clj-call-invoke
+  "Calls the output wrapper"
   [{:keys [full-name params ns-name creation-stack]} & args]
   (clj_headlights.System/ensureInitialized ns-name)
   (try

--- a/test/clj_headlights/t_pipeline.clj
+++ b/test/clj_headlights/t_pipeline.clj
@@ -50,6 +50,9 @@
       (df-test/pcoll-is [2] pcoll))))
 
 (defn times-ten [x] [x (* 10 x)])
+
+(defn times-n [x n] [x (* n x)])
+
 (deftest df-mapcat
   (testing "it outputs multiple values"
     (let [pcoll (-> (df-test/create-pcoll [1 2])
@@ -60,7 +63,11 @@
   (testing "it outputs one value"
     (let [pcoll (-> (df-test/create-pcoll [1 2])
                     (df/df-map "map" #'times-ten))]
-      (df-test/pcoll-is [[1 10] [2 20]] pcoll))))
+      (df-test/pcoll-is [[1 10] [2 20]] pcoll)))
+  (testing "it outputs times n using args"
+    (let [pcoll (-> (df-test/create-pcoll [1 2])
+                    (df/df-map "map" [#'times-n 2]))]
+      (df-test/pcoll-is [[1 2] [2 4]]  pcoll))))
 
 (defn add-keyword [x kw] [1 [kw x]])
 


### PR DESCRIPTION
Beam provides a Context and Window object that are passed to DoFns. This PR allows the user to get those objects in their clojure pardo fns. 

It additionally adds a test showing how to pass params to clojure pardo fns. 

I also updated some docs. 

It's hard to test this so I just added a case to df-map that asserts that the fn gets the objects. I also changed the side output test to assert that it can get the objects. 